### PR TITLE
enh: add new helpers for templates

### DIFF
--- a/girder_jsonforms/web_client/views/EditFormView.js
+++ b/girder_jsonforms/web_client/views/EditFormView.js
@@ -118,11 +118,21 @@ const EditFormView = View.extend({
         Handlebars.registerHelper('divide', function (a, b) { return a / b; });
         Handlebars.registerHelper('add', function (a, b) { return a + b; });
         Handlebars.registerHelper('subtract', function (a, b) { return a - b; });
+        Handlebars.registerHelper('replace', function (string, search, replacement) {
+            return (string !== undefined && string !== null) ? string.replace(search, replacement) : '';
+        });
+        Handlebars.registerHelper('replaceAll', function (string, search, replacement) {
+            return (string !== undefined && string !== null) ? string.replaceAll(search, replacement) : '';
+        });
         Handlebars.registerHelper('substr', function (string, from, length) {
-            return string !== undefined ? string.substr(from, length) : '';
+            return (string !== undefined && string !== null) ? string.substr(from, length) : '';
         });
         Handlebars.registerHelper('split', function (string, separator, index) {
-            return string.split(separator)[index];
+            try {
+                return string.split(separator)[index];
+            } catch (e) {
+                return '';
+            }
         });
         Handlebars.registerHelper('join', function (a, b, separator) {
             return `${a}${separator}${b}`;

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     name="girder-jsonforms",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    version="2.0.2",
+    version="2.0.3",
     description="Girder plugin adding forms based on JSON-editor",
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
- Add `replace` and `replaceAll`
- fix `split` to work in case input is ill defined or causes out of bound access in array