### PR TITLE
Only authenticate with GDrive if setting is enabled. Fixes #13

### DIFF
--- a/girder_jsonforms/settings.py
+++ b/girder_jsonforms/settings.py
@@ -1,0 +1,26 @@
+from girder.exceptions import ValidationException
+from girder.utility import setting_utilities
+
+
+class PluginSettings:
+    GOOGLE_DRIVE_ENABLED = "jsonforms.google_drive_enabled"
+
+
+@setting_utilities.default(PluginSettings.GOOGLE_DRIVE_ENABLED)
+def default_google_drive_enabled():
+    """
+    Default setting for enabling Google Drive integration.
+    """
+    return False
+
+
+@setting_utilities.validator(PluginSettings.GOOGLE_DRIVE_ENABLED)
+def validate_google_drive_enabled(doc):
+    """
+    Validate the Google Drive integration setting.
+    """
+    if not isinstance(doc["value"], bool):
+        raise ValidationException(
+            "Google Drive integration must be a boolean.",
+            "value",
+        )

--- a/girder_jsonforms/tests/test_gdrive.py
+++ b/girder_jsonforms/tests/test_gdrive.py
@@ -1,0 +1,43 @@
+import pytest
+from girder import plugin
+from girder.models.setting import Setting
+from girder_jsonforms.settings import PluginSettings
+
+
+@pytest.fixture
+def enable_gdrive(db):
+    Setting().set(PluginSettings.GOOGLE_DRIVE_ENABLED, True)
+    yield
+    Setting().set(PluginSettings.GOOGLE_DRIVE_ENABLED, False)
+
+
+@pytest.fixture
+def mock_authorization(mocker):
+    mock_auth = mocker.patch("girder_jsonforms.authenticate_gdrive")
+    mock_auth.return_value = {"status": "Authorized"}
+    return mock_auth
+
+
+@pytest.fixture
+def mock_apiRoot(mocker):
+    mock_api = mocker.Mock()
+    return mock_api
+
+
+@pytest.mark.plugin("jsonforms")
+def test_disabled_gdrive():
+    from girder_jsonforms import GDRIVE_SERVICE as GDRIVE
+
+    assert GDRIVE is None, "Google Drive plugin should be disabled"
+
+
+def test_enabled_gdrive(enable_gdrive, mock_authorization, mock_apiRoot):
+    assert plugin.loadedPlugins() == []
+
+    plugin._loadPlugins(
+        info={"apiRoot": mock_apiRoot, "serverRoot": mock_apiRoot}, names=["jsonforms"]
+    )
+
+    from girder_jsonforms import GDRIVE_SERVICE as GDRIVE
+
+    assert GDRIVE == {"status": "Authorized"}, "Google Drive should be enabled"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-cov
+pytest-mock
 pytest-girder>=5.0.0a5.dev0


### PR DESCRIPTION
Add a proper setting to control whether we authenticate with Google or not.