### PR TITLE
fix: formId in GET /entry should be a query arg

### DIFF
--- a/girder_jsonforms/rest/entry.py
+++ b/girder_jsonforms/rest/entry.py
@@ -26,6 +26,7 @@ class FormEntry(Resource):
             "The ID of the form",
             model=FormModel,
             level=AccessType.READ,
+            paramType="query",
             required=False,
         )
         .pagingParams(defaultSort="created")


### PR DESCRIPTION
Surprisingly only swagger was broken by this...