### PR TITLE
fix: use proper qarg for export format

### DIFF
--- a/girder_jsonforms/web_client/models/FormModel.js
+++ b/girder_jsonforms/web_client/models/FormModel.js
@@ -4,7 +4,7 @@ const { getApiRoot } = girder.rest;
 var FormModel = AccessControlledModel.extend({
     resourceName: 'form',
     exportForm: function (format) {
-      let url = `${getApiRoot()}/${this.resourceName}/${this.id}/export?format=${format}`;
+      let url = `${getApiRoot()}/${this.resourceName}/${this.id}/export?exportFormat=${format}`;
       return url;
     }
 });


### PR DESCRIPTION
Due to the bad query argument name export was always returning csv.